### PR TITLE
Fix issues with devDependencies to support Typescript projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # PNPM compatible Buildpack for Heroku and Node.js
 
-This is an unofficial buildpack for the official [Heroku buildpack](http://devcenter.heroku.com/articles/buildpacks) for Node.js apps. This version was forked from https://github.com/unfold/heroku-buildpack-pnpm to fix issues with `devDependencies` when building Typescript projects.
+This is an unofficial buildpack for the official [Heroku buildpack](http://devcenter.heroku.com/articles/buildpacks) for Node.js apps.
 
 It supports pnpm in addition to yarn/npm. As long as the root of your project contains a `pnpm-lock.yaml` file, PNPM will be used to install all dependencies.
 
 ## Documentation
 
-This will run a regular `pnpm install` in the Heroku environment. It temporarily overrides the NODE_ENV variable during this step so it will install the `devDependencies`, and then it runs `pnpm prune --prod` during the prune step to remove the `devDependencies`.
+This will run a regular `pnpm install` in the Heroku environment. It will install `devDependencies` initially, regardless of the NODE_ENV setting, and then runs `pnpm prune --prod` during the prune step to remove the `devDependencies`.
 
 The pnpm store will automatically be cached, you do not need to specify additional cache directories manually.
 
@@ -26,7 +26,7 @@ For more general information about buildpacks on Heroku:
 It's suggested that you use the latest version of the release buildpack. You can set it using the `heroku-cli`.
 
 ```sh
-heroku buildpacks:set https://github.com/TheSecurityDev/heroku-buildpack-nodejs-pnpm
+heroku buildpacks:set https://github.com/unfold/heroku-buildpack-pnpm
 ```
 
 Your builds will always used the latest published release of the buildpack.
@@ -36,7 +36,7 @@ You can control the version of pnpm but setting a `PNPM_VERSION` environment var
 If you need to use the git url, you can use the `latest` tag to make sure you always have the latest release. **The `main` branch will always have the latest buildpack updates, but it does not correspond with a numbered release.**
 
 ```sh
-heroku buildpacks:set https://github.com/TheSecurityDev/heroku-buildpack-nodejs-pnpm#latest -a my-app
+heroku buildpacks:set https://github.com/unfold/heroku-buildpack-pnpm#latest -a my-app
 ```
 
 ### Chain Node with multiple buildpacks

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # PNPM compatible Buildpack for Heroku and Node.js
 
-This is an unofficial for of the official [Heroku buildpack](http://devcenter.heroku.com/articles/buildpacks) for Node.js apps.
+This is an unofficial buildpack for the official [Heroku buildpack](http://devcenter.heroku.com/articles/buildpacks) for Node.js apps. This version was forked from https://github.com/unfold/heroku-buildpack-pnpm to fix issues with `devDependencies` when building Typescript projects.
 
 It supports pnpm in addition to yarn/npm. As long as the root of your project contains a `pnpm-lock.yaml` file, PNPM will be used to install all dependencies.
 
 ## Documentation
 
-This will run a regular `pnpm install` in the Heroku environment. It will NOT install dev depdencies.
+This will run a regular `pnpm install` in the Heroku environment. It temporarily overrides the NODE_ENV variable during this step so it will install the `devDependencies`, and then it runs `pnpm prune --prod` during the prune step to remove the `devDependencies`.
 
 The pnpm store will automatically be cached, you do not need to specify additional cache directories manually.
 
@@ -26,7 +26,7 @@ For more general information about buildpacks on Heroku:
 It's suggested that you use the latest version of the release buildpack. You can set it using the `heroku-cli`.
 
 ```sh
-heroku buildpacks:set https://github.com/unfold/heroku-buildpack-pnpm
+heroku buildpacks:set https://github.com/TheSecurityDev/heroku-buildpack-nodejs-pnpm
 ```
 
 Your builds will always used the latest published release of the buildpack.
@@ -36,7 +36,7 @@ You can control the version of pnpm but setting a `PNPM_VERSION` environment var
 If you need to use the git url, you can use the `latest` tag to make sure you always have the latest release. **The `main` branch will always have the latest buildpack updates, but it does not correspond with a numbered release.**
 
 ```sh
-heroku buildpacks:set https://github.com/unfold/heroku-buildpack-pnpm#latest -a my-app
+heroku buildpacks:set https://github.com/TheSecurityDev/heroku-buildpack-nodejs-pnpm#latest -a my-app
 ```
 
 ### Chain Node with multiple buildpacks

--- a/bin/compile
+++ b/bin/compile
@@ -222,6 +222,7 @@ install_bins() {
 
   if $PNPM; then
     meta_set "build-step" "install-pnpm"
+    echo ""
     echo "-----> Install pnpm"
     curl -sL https://unpkg.com/@pnpm/self-installer | node
     pnpm config set store-dir "$CACHE_DIR"/.pnpm-store
@@ -363,7 +364,7 @@ prune_devdependencies() {
   if $YARN || $YARN_2; then
     yarn_prune_devdependencies "$BUILD_DIR" "$YARN_CACHE_FOLDER"
   elif $PNPM; then
-    echo "Not pruning when using pnpm"
+    pnpm_prune_devdependencies "$BUILD_DIR"
   else
     npm_prune_devdependencies "$BUILD_DIR"
   fi

--- a/bin/compile
+++ b/bin/compile
@@ -222,10 +222,10 @@ install_bins() {
 
   if $PNPM; then
     meta_set "build-step" "install-pnpm"
-    echo ""
-    echo "-----> Install pnpm"
+    echo "Downloading and installing pnpm..."
     curl -sL https://unpkg.com/@pnpm/self-installer | node
     pnpm config set store-dir "$CACHE_DIR"/.pnpm-store
+    echo "pnpm $(pnpm --version) installed"
   fi
 
   # Download yarn if there is a yarn.lock file or if the user

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -146,7 +146,7 @@ pnpm_node_modules() {
 
   echo "Installing node modules (pnpm-lock.yaml)"
   cd "$build_dir" || return
-  monitor "pnpm-install" NODE_ENV=build pnpm install
+  monitor "pnpm-install" pnpm cross-env NODE_ENV=build pnpm install
 }
 
 yarn_2_install() {

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -146,7 +146,7 @@ pnpm_node_modules() {
 
   echo "Installing node modules (pnpm-lock.yaml)"
   cd "$build_dir" || return
-  monitor "pnpm-install" pnpm install
+  monitor "pnpm-install" NODE_ENV=build pnpm install
 }
 
 yarn_2_install() {
@@ -323,6 +323,31 @@ npm_prune_devdependencies() {
   else
     cd "$build_dir" || return
     monitor "npm-prune" npm prune --userconfig "$build_dir/.npmrc" 2>&1
+    meta_set "skipped-prune" "false"
+  fi
+}
+
+pnpm_prune_devdependencies() {
+  local pnpm_version
+  local build_dir=${1:-}
+
+  pnpm_version=$(pnpm --version)
+
+  if [ "$NODE_ENV" == "test" ]; then
+    echo "Skipping because NODE_ENV is 'test'"
+    meta_set "skipped-prune" "true"
+    return 0
+  elif [ "$NODE_ENV" != "production" ]; then
+    echo "Skipping because NODE_ENV is not 'production'"
+    meta_set "skipped-prune" "true"
+    return 0
+  elif [ -n "$NPM_CONFIG_PRODUCTION" ]; then
+    echo "Skipping because NPM_CONFIG_PRODUCTION is '$NPM_CONFIG_PRODUCTION'"
+    meta_set "skipped-prune" "true"
+    return 0
+  else
+    cd "$build_dir" || return
+    monitor "pnpm-prune" pnpm prune --prod 2>&1
     meta_set "skipped-prune" "false"
   fi
 }

--- a/lib/dependencies.sh
+++ b/lib/dependencies.sh
@@ -146,7 +146,7 @@ pnpm_node_modules() {
 
   echo "Installing node modules (pnpm-lock.yaml)"
   cd "$build_dir" || return
-  monitor "pnpm-install" pnpm cross-env NODE_ENV=build pnpm install
+  monitor "pnpm-install" env NODE_ENV=build pnpm install 2>&1
 }
 
 yarn_2_install() {


### PR DESCRIPTION
This pull request changes how PNPM installs `devDependencies` to behave more like the official NodeJS buildpack.

It temporarily overrides the NODE_ENV variable when running `pnpm install` to force it to install `devDependencies`. Then during the prune step it runs `pnpm prune --prod` to remove the `devDependencies`. This allows building Typescript projects without moving `typescript` out of `devDependencies`.