### PR TITLE
Use `npm` to install `pnpm`

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -228,11 +228,7 @@ install_bins() {
   if $PNPM || [ -n "$pnpm_engine" ]; then
     meta_set "build-step" "install-pnpm"
     echo "Downloading and installing pnpm..."
-    if [ -z "$pnpm_engine" ]; then
-      npm install --global pnpm
-    else
-      npm install --global pnpm@"$pnpm_engine"
-    fi
+    npm install --global pnpm@"${pnpm_engine:latest}"
     pnpm config set store-dir "$CACHE_DIR"/.pnpm-store
     echo "pnpm $(pnpm --version) installed"
   fi

--- a/bin/compile
+++ b/bin/compile
@@ -226,9 +226,9 @@ install_bins() {
     meta_set "build-step" "install-pnpm"
     echo "Downloading and installing pnpm..."
     if [ -z "$pnpm_engine" ]; then
-      curl -sL https://unpkg.com/@pnpm/self-installer | node
+      npm install --global pnpm
     else
-      curl -sL https://unpkg.com/@pnpm/self-installer | PNPM_VERSION=$pnpm_engine node
+      npm install --global pnpm@"$pnpm_engine"
     fi
     pnpm config set store-dir "$CACHE_DIR"/.pnpm-store
     echo "pnpm $(pnpm --version) installed"

--- a/bin/compile
+++ b/bin/compile
@@ -231,7 +231,9 @@ install_bins() {
   if $PNPM || [ -n "$pnpm_engine" ]; then
     meta_set "build-step" "install-pnpm"
     echo "Downloading and installing pnpm..."
-    npm install --global pnpm@"${pnpm_engine:latest}"
+    if ! npm install --global "pnpm@${pnpm_engine:latest}" 2>@1>/dev/null; then
+      echo "Unable to install pnpm ${pnpm_engine:latest}; does it exist?" && false
+    fi
     pnpm config set store-dir "$CACHE_DIR"/.pnpm-store
     echo "pnpm $(pnpm --version) installed"
   fi

--- a/bin/compile
+++ b/bin/compile
@@ -222,7 +222,10 @@ install_bins() {
   mcount "version.node.$node_version"
   meta_set "node-version" "$node_version"
 
-  if $PNPM; then
+  # Download pnpm if there is a pnpm-lock.yaml file or if the user
+  # has specified a version of pnpm under "engines". We'll still
+  # only install using pnpm if there is a pnpm-lock.yaml file
+  if $PNPM || [ -n "$pnpm_engine" ]; then
     meta_set "build-step" "install-pnpm"
     echo "Downloading and installing pnpm..."
     if [ -z "$pnpm_engine" ]; then

--- a/bin/compile
+++ b/bin/compile
@@ -208,6 +208,9 @@ install_bins() {
   if $YARN || [ -n "$yarn_engine" ]; then
     echo "engines.yarn (package.json):  ${yarn_engine:-unspecified (use default)}"
   fi
+  if $PNPM || [ -n "$pnpm_engine" ]; then
+    echo "engines.pnpm (package.json):  ${pnpm_engine:-unspecified (use default)}"
+  fi
   echo ""
 
   warn_node_engine "$node_engine"


### PR DESCRIPTION
https://www.npmjs.com/package/@pnpm/self-installer?activeTab=readme says:

> WARNING: This installation method is not supported anymore.

so instead of using this outdated method to install `pnpm` this PR is switching the code over to using `npm install --global` instead (see https://pnpm.io/installation#using-npm).

I first tried using their standalone script (see https://pnpm.io/installation#using-a-standalone-script), but that would require us to `source` a bash script at a generated location which makes the installation a little brittle. Since installation via npm is also officially supported and fast enough we can use that instead. The "quiet" installation via npm is modeled after how it's done in the `install_npm()` function too.

I've also taken the opportunity to adjust the code so that it will also install `pnpm` if `engines.pnpm` is set, but there is no pnpm lockfile. This matches the behavior for yarn now.

Resolves https://github.com/unfold/heroku-buildpack-pnpm/issues/39