### PR TITLE
Extend pnpm_prune_devdependencies to support monorepos and prune subfolders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,36 +1,48 @@
 # Node.js Buildpack Changelog
 
+## (2023-05-04)
+
+- Extend pnpm_prune_devdependencies to support monorepos and prune subfolders ([#45](https://github.com/unfold/heroku-buildpack-pnpm/pull/45))
+
 ## main
+
 - Add Yarn 1.22.1{2,3,4,5} to `inventory/yarn.toml` ([#947](https://github.com/heroku/heroku-buildpack-nodejs/pull/947))
 
 ## v189 (2021-09-14)
+
 - Revert non-zero-install support from #888 ([#944](https://github.com/heroku/heroku-buildpack-nodejs/pull/944))
 
 ## v188 (2021-09-10)
+
 - Update Node version inventory, includes 12.22.6, 14.17.6, 16.8.0, 16.7.0 and others ([#940](https://github.com/heroku/heroku-buildpack-nodejs/pull/940))
 - Support non-zero-install support for Yarn 2 ([#888](https://github.com/heroku/heroku-buildpack-nodejs/pull/888))
 
 ## v187 (2021-09-02)
+
 - Upgrade heroku_hatchet to 7.3.4 to get CI green again ([#936](https://github.com/heroku/heroku-buildpack-nodejs/pull/936))
 - Fix typo in conflicting lockfile failure message ([#901](https://github.com/heroku/heroku-buildpack-nodejs/pull/901))
 - Use local packages with Yarn when present ([#913](https://github.com/heroku/heroku-buildpack-nodejs/pull/913))
 - Add support for running "npm ci" when "npm-shrinkwrap.json" is found on the project directory ([#938](https://github.com/heroku/heroku-buildpack-nodejs/pull/938))
 
 ## v186 (2021-08-11)
+
 - Refactor $WEB_CONCURRENCY logic ([#931](https://github.com/heroku/heroku-buildpack-nodejs/pull/931))
 - Fix broken tests, update node and yarn inventory, update shunit2 ([#934](https://github.com/heroku/heroku-buildpack-nodejs/pull/934))
 - Fix NODE_BINARY_URL extraction prefix stripping logic ([#928](https://github.com/heroku/heroku-buildpack-nodejs/pull/928))
 
 ## v185 (2021-06-03)
+
 - Drop Heroku-16 from CI test matrix ([#920](https://github.com/heroku/heroku-buildpack-nodejs/pull/920))
 - Add metrics plugin for Node 16 ([#923](https://github.com/heroku/heroku-buildpack-nodejs/pull/923))
 
 ## v184 (2021-05-20)
+
 - Prune devDependencies with Yarn 2 ([#891](https://github.com/heroku/heroku-buildpack-nodejs/pull/891))
 - Add 10.x, 12.x, and 14.x to inventory ([902](https://github.com/heroku/heroku-buildpack-nodejs/pull/902))
 - Fix yarn workspace plugin detection ([#905](https://github.com/heroku/heroku-buildpack-nodejs/pull/905))
 
 ## v183 (2021-02-03)
+
 - Update node version to 14 ([#885](https://github.com/heroku/heroku-buildpack-nodejs/pull/885))
 - Add unit tests around the behavior of `WEB_CONCURRENCY` ([#876](https://github.com/heroku/heroku-buildpack-nodejs/pull/876))
 - Add Node v15.6.0 to inventory ([#892](https://github.com/heroku/heroku-buildpack-nodejs/pull/892))
@@ -40,39 +52,47 @@
 - Add Node v15.8.0 to inventory ([#897](https://github.com/heroku/heroku-buildpack-nodejs/pull/897))
 
 ## v182 (2021-01-05)
+
 - add Node 14.15.3 and 15.5.0 to inventory ([#881](https://github.com/heroku/heroku-buildpack-nodejs/pull/881))
 - Report on parsing errors for `resolve-version.rs` ([#883](https://github.com/heroku/heroku-buildpack-nodejs/pull/883))
 - Add an environment variable for using npm install (instead of npm ci) ([#882](https://github.com/heroku/heroku-buildpack-nodejs/pull/882))
 - add Node 10.23.1, 12.20.1, 14.15.4, and 15.5.1 to inventory ([#886](https://github.com/heroku/heroku-buildpack-nodejs/pull/886))
 
 ## v181 (2020-12-16)
+
 - Warn to use build flag with ng build as build script ([#878](https://github.com/heroku/heroku-buildpack-nodejs/pull/878))
 - add Node 14.15.2 to inventory ([#879](https://github.com/heroku/heroku-buildpack-nodejs/pull/879))
 
 ## v180 (2020-12-09)
+
 - add Node 15.4.0 to inventory ([#873](https://github.com/heroku/heroku-buildpack-nodejs/pull/873))
 
 ## v179 (2020-12-07)
+
 - Fix syntax for passing in script flags for npm build script ([#869](https://github.com/heroku/heroku-buildpack-nodejs/pull/869))
 - add Node 15.3.0 and 12.20.0 to inventory ([#870](https://github.com/heroku/heroku-buildpack-nodejs/pull/870))
 
 ## v178 (2020-11-17)
+
 - Add NODE_BUILD_FLAG env var ([#859](https://github.com/heroku/heroku-buildpack-nodejs/pull/859))
 - Add 12.19.1, 14.15.1, and 15.2.1 to inventory for security releases ([#865](https://github.com/heroku/heroku-buildpack-nodejs/pull/865))
 
 ## v177 (2020-11-12)
+
 - add Node 15.2.0 to inventory ([#861](https://github.com/heroku/heroku-buildpack-nodejs/pull/861))
 - Use jq from the stack image ([#854](https://github.com/heroku/heroku-buildpack-nodejs/pull/854))
 - Start testing new `resolve` binaries with inventory lists for Node and Yarn ([#855](https://github.com/heroku/heroku-buildpack-nodejs/pull/855))
 - Follow up to [#855](https://github.com/heroku/heroku-buildpack-nodejs/pull/855) to send captured data with bin/report ([#858](https://github.com/heroku/heroku-buildpack-nodejs/pull/858))
 
 ## v176 (2020-09-10)
+
 - Only run immutable cache in yarn 2 if caching enabled ([#832](https://github.com/heroku/heroku-buildpack-nodejs/pull/832))
 - Added Hatchet regression tests ([#833](https://github.com/heroku/heroku-buildpack-nodejs/pull/833))
 - Delete unused fixtures ([#835](https://github.com/heroku/heroku-buildpack-nodejs/pull/835))
 - Expand `npm ci` usage to 100% of builds ([#842](https://github.com/heroku/heroku-buildpack-nodejs/pull/842))
 
 ## v175 (2020-08-13)
+
 - Install Yarn version at 1.22.x when not specified in package.json engines ([#817](https://github.com/heroku/heroku-buildpack-nodejs/pull/817))
 - Run `yarn install` for all Yarn 2 builds ([#819](https://github.com/heroku/heroku-buildpack-nodejs/pull/819))
 - Change all references from Yarn2 to Yarn 2 ([#824](https://github.com/heroku/heroku-buildpack-nodejs/pull/824))
@@ -80,11 +100,13 @@
 - Detect for "node-modules" nodeLinker for Yarn 2 ([#828](https://github.com/heroku/heroku-buildpack-nodejs/pull/828))
 
 ## v174 (2020-07-23)
+
 - provide custom binary url for node and yarn binary downloads ([#804](https://github.com/heroku/heroku-buildpack-nodejs/pull/804))
 - allow skipping node_modules removal with SKIP_NODE_MODULES_CHECK ([#798](https://github.com/heroku/heroku-buildpack-nodejs/pull/798))
 - expand npm ci usage to 75% of builds ([#812](https://github.com/heroku/heroku-buildpack-nodejs/pull/812))
 
 ## v173 (2020-07-16)
+
 - update docs URL when node modules are checked into git ([#794](https://github.com/heroku/heroku-buildpack-nodejs/pull/794))
 - move disabling yarn caching YARN_CACHE env var ([#796](https://github.com/heroku/heroku-buildpack-nodejs/pull/796))
 - use meta_get "node-package-manager" for reporting ([#802](https://github.com/heroku/heroku-buildpack-nodejs/pull/802))
@@ -93,6 +115,7 @@
 - edits to Yarn 2 info and warning messaging ([#806](https://github.com/heroku/heroku-buildpack-nodejs/pull/806))
 
 ### feature: Yarn 2 support
+
 - Add warning for detection of Yarn 2 usage with caching ([#755](https://github.com/heroku/heroku-buildpack-nodejs/pull/755))
 - Add warning for Yarn 2 usage, warn user of ignoring engine from package.json ([#761](https://github.com/heroku/heroku-buildpack-nodejs/pull/761))
 - Add warning for if .npmrc file exists when using Yarn 2 ([#764](https://github.com/heroku/heroku-buildpack-nodejs/pull/764))
@@ -104,6 +127,7 @@
 - Test use of packages in `.yarn/release` directory ([#786](https://github.com/heroku/heroku-buildpack-nodejs/pull/786))
 
 ## v172 (2020-05-28)
+
 - display yarn engine log to build output when engine is provided in monorepo ([#771](https://github.com/heroku/heroku-buildpack-nodejs/pull/771))
 - move proxy issues section from readme to dev center ([#778](https://github.com/heroku/heroku-buildpack-nodejs/pull/778))
 - warn when NO_PROXY is not set to "amazonaws.com" and HTTP_PROXY or HTTPS_PROXY is set ([#782](https://github.com/heroku/heroku-buildpack-nodejs/pull/782))
@@ -111,6 +135,7 @@
 - add a build step for cleanup script and output to log file ([#790](https://github.com/heroku/heroku-buildpack-nodejs/pull/790))
 
 ## v171 (2020-04-27)
+
 - Update Travis badge to `master` and other changes in README ([#753](https://github.com/heroku/heroku-buildpack-nodejs/pull/753))
 - Up feature flag test groups ([#758](https://github.com/heroku/heroku-buildpack-nodejs/pull/758))
 - Add Heroku-20 to the Travis test matrix ([#763](https://github.com/heroku/heroku-buildpack-nodejs/pull/763))
@@ -118,6 +143,7 @@
 - Add spec support for Node 13 and 14 ([#766](https://github.com/heroku/heroku-buildpack-nodejs/pull/766))
 
 ## v170 (2020-03-31)
+
 - Bump rake from 12.3.1 to 12.3.3 ([#742](https://github.com/heroku/heroku-buildpack-nodejs/pull/742))
 - Upgrade Go to 1.14 ([#744](https://github.com/heroku/heroku-buildpack-nodejs/pull/744))
 - Bump `npm ci` usage for installing dependencies to 20% ([#745](https://github.com/heroku/heroku-buildpack-nodejs/pull/745))
@@ -126,18 +152,22 @@
 - Move etc/vendor to lib/vendor ([#750](https://github.com/heroku/heroku-buildpack-nodejs/pull/750))
 
 ## v167 (2020-02-06)
+
 - Make minor upgrades to gems ([#735](https://github.com/heroku/heroku-buildpack-nodejs/pull/735))
 - Fix typo in failure metadata call ([#737](https://github.com/heroku/heroku-buildpack-nodejs/pull/737))
 
 ## v166 (2019-12-16)
+
 - Add Node 13 metrics plugin ([#731](https://github.com/heroku/heroku-buildpack-nodejs/pull/731), [#732](https://github.com/heroku/heroku-buildpack-nodejs/pull/732))
 - Fix yarn cache feature flag ([#729](https://github.com/heroku/heroku-buildpack-nodejs/pull/729))
 
 ## v165 (2019-10-24)
+
 - Update README ([#725](https://github.com/heroku/heroku-buildpack-nodejs/pull/725))
 - Update default Node version to 12.x ([#724](https://github.com/heroku/heroku-buildpack-nodejs/pull/724))
 
 ## v164 (2019-10-17)
+
 - Avoid issues in environments requiring proxies for all connections (#708)
 - Extend metadata module in preparation for bin/report work (#709)
 - Vendor the buildpack stdlib (#710)
@@ -146,97 +176,125 @@
 - Extend bin/report (#718)
 
 ## v163 (2019-09-12)
+
 - Add a minimal version of bin/report. Not user-facing (#700)
 
 ## v162 (2019-09-03)
+
 - Replace broken kb.heroku.com links with help.heroku.com shortlinks (#698)
 
 ## v161 (2019-08-15)
+
 - Expand A/B test of native yarn caching to 50% of apps (#695)
 
 ## v160 (2019-08-07)
+
 - Roll out A/B test of native yarn caching to a small set of apps (#693)
 
 ## v159 (2019-08-01)
+
 - Updates to metadata saved (#689, #690)
 - Add native yarn cache caching behind a flag (#691)
 
 ## v158 (2019-07-10)
+
 - Don't suppress curl errors (#680)
 - Add logging to track yarn workspace usage (#685)
 - Log out number of js, jsx, and ts files (#686)
 
 ## v157 (2019-06-17)
+
 - Prevent `HTTP_PROXY` env var from blocking version-resolution binary
 
 ## v156 (2019-06-12)
+
 - Turn off npm ci experiment
 
 ## v155 (2019-06-06)
+
 - Add metadata for build steps (#677)
 
 ## v154 (2019-06-05)
+
 - Roll out A/B test of npm ci command to 5% of apps (#676)
 - Internal fixes (#674, #673)
 
 ## v153 (2019-05-30)
+
 - Test new A/B testing module (#671, #672)
 
 ## v152 (2019-05-28)
+
 - Replace nodebin usage in hatchet tests (#669)
 - Add ability to list all node or yarn releases (#668)
 
 ## v151 (2019-05-28)
+
 - Deprecate nodebin in favor of go binary (#667)
 
 ## v150 (2019-05-22)
+
 - Resolve more inconsistencies with version selection (#666)
 
 ## v149 (2019-05-10)
+
 - Resolve the known behavior mismatches between nodebin and the go logic (#664)
 
 ## v148 (2019-05-02)
+
 - Dark-launch new semver matching logic for node binaries (#663)
 
 ## v147 (2019-05-01)
+
 - Dark-launch new semver matching logic for yarn binaries (#661)
 - Add node 12.x as a supported version for Node Metrics beta (#662)
 
 ## v146 (2019-04-25)
+
 - Deprecate io.js as an alternative runtime (#658)
 - Prototyping new version resolution approach to replace Nodebin (#649 - #657)
 
 ## v145 (2019-04-16)
+
 - Separate prebuild step in log output (#646)
 - Clean up script metrics and logging (#647)
 
 ## v144 (2019-04-08)
+
 - Remove temporary wraning about "run build" change (#644)
 
 ## v143 (2019-03-28)
+
 - Internal logging changes (#637, #631, #630)
 
 ## v142 (2019-03-11)
+
 - Add temporary warning about "run build" when the build fails as well (#639)
 
 ## v141 (2019-03-11)
+
 - Add temporary warning about "run build" change to log output (#636)
 
 ## v140 (2019-03-11)
+
 - Run the build script by default (#628)
 
 ## v139 (2019-03-04)
+
 - Make breaking change warning header brighter (#627)
 
 ## v138 (2019-02-20)
+
 - Add new Build header (#625)
 - Fix yarn run error when script is empty string (#624)
 
 ## v137 (2019-02-14)
+
 - Internal logging changes (#620, #618, #621)
 - Detect build scripts even when they are empty (#617)
 
 ## v136 (2019-02-09)
+
 - Add warning for the upcoming run build change (#616)
 
 ## v135 (2019-02-06)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It supports pnpm in addition to yarn/npm. As long as the root of your project co
 
 This will run a regular `pnpm install` in the Heroku environment. It will install `devDependencies` initially, regardless of the NODE_ENV setting, and then runs `pnpm prune --prod` during the prune step to remove the `devDependencies`.
 
-If a monorepo is detected (by the presence of a pnpm-workspace.yaml file or a workspaces field in the root package.json file), the buildpack will iterate through all subfolders containing a package.json file and prune their devDependencies using the pnpm prune --prod command.
+If a monorepo is detected (by the presence of a pnpm-workspace.yaml file or a workspaces field in the root package.json file), the buildpack will iterate through all subfolders containing a package.json file and prune their devDependencies using the `pnpm prune --prod` command.
 
 This allows for better slug size optimization in monorepo projects by removing unnecessary devDependencies from subfolders.
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ It supports pnpm in addition to yarn/npm. As long as the root of your project co
 
 This will run a regular `pnpm install` in the Heroku environment. It will install `devDependencies` initially, regardless of the NODE_ENV setting, and then runs `pnpm prune --prod` during the prune step to remove the `devDependencies`.
 
+If a monorepo is detected (by the presence of a pnpm-workspace.yaml file or a workspaces field in the root package.json file), the buildpack will iterate through all subfolders containing a package.json file and prune their devDependencies using the pnpm prune --prod command.
+
+This allows for better slug size optimization in monorepo projects by removing unnecessary devDependencies from subfolders.
+
 The pnpm store will automatically be cached, you do not need to specify additional cache directories manually.
 
 For more information about using this Node.js buildpack on Heroku, see these Dev Center articles:


### PR DESCRIPTION
This pull request updates the pnpm_prune_devdependencies function in the Heroku buildpack to support monorepos and prune dev dependencies in subfolders as necessary. The updated function checks for the presence of a pnpm-workspace.yaml file or a workspaces field in the root package.json file to determine if the project is a monorepo. If it is a monorepo, the function iterates through all subfolders (depth=2) containing a package.json file and prunes their dev dependencies using the pnpm prune --prod command.

Changes in this PR include:

1. Update the pnpm_prune_devdependencies function to check for a monorepo configuration.
2. If a monorepo is detected, find all subfolders containing a package.json file and prune their dev dependencies.
3. Preserve the existing behavior for non-monorepo projects.

This enhancement allows developers to optimize slug size for monorepo projects by removing unnecessary dev dependencies from subfolders, resulting (hopefully) in faster deployment times and improved performance on Heroku.